### PR TITLE
Enable SysEx on RtMidi

### DIFF
--- a/src/midi_rtmidi.cpp
+++ b/src/midi_rtmidi.cpp
@@ -30,6 +30,7 @@ int MIDI_Init(int port)
     }
 
     s_midi_in = new RtMidiIn(RtMidi::UNSPECIFIED, "Nuked SC55", 1024);
+    s_midi_in->ignoreTypes(false, false, false); // SysEx disabled by default
     s_midi_in->setCallback(&MidiOnReceive, nullptr); // FIXME: (local bug) Fix the linking error
     s_midi_in->setErrorCallback(&MidiOnError, nullptr);
 


### PR DESCRIPTION
RtMidi by default seems to filter out several types of MIDI messages including SysEx, which is undesirable when emulating an hardware MIDI synth.

Reference: https://www.music.mcgill.ca/~gary/rtmidi/classRtMidiIn.html#af9507125aaa42276ccc01df576fc3533