### PR TITLE
Added command line option to select audio output device.

### DIFF
--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -1054,7 +1054,7 @@ static const char* audio_format_to_str(int format)
     return "UNK";
 }
 
-int MCU_OpenAudio(void)
+int MCU_OpenAudio(int deviceIndex)
 {
     SDL_AudioSpec spec = {};
     SDL_AudioSpec spec_actual = {};
@@ -1064,12 +1064,16 @@ int MCU_OpenAudio(void)
     spec.channels = 2;
     spec.callback = audio_callback;
     spec.samples = audio_page_size / 4;
+    
+    const char* audioDevicename = SDL_GetAudioDeviceName(deviceIndex, 0);
 
-    sdl_audio = SDL_OpenAudioDevice(NULL, 0, &spec, &spec_actual, 0);
+    sdl_audio = SDL_OpenAudioDevice(audioDevicename, 0, &spec, &spec_actual, 0);
     if (!sdl_audio)
     {
         return 0;
     }
+    
+    printf("Audio Device: %s\n", audioDevicename);
 
     printf("Audio Requested: F=%s, C=%d, R=%d, B=%d\n",
            audio_format_to_str(spec.format),
@@ -1151,6 +1155,7 @@ int main(int argc, char *argv[])
     std::string basePath;
 
     int port = 0;
+    int audioDeviceIndex = 0;
     bool autodetect = true;
 
     romset = ROM_SET_MK2;
@@ -1161,6 +1166,10 @@ int main(int argc, char *argv[])
             if (!strncmp(argv[i], "-p:", 3))
             {
                 port = atoi(argv[i] + 3);
+            }
+            else if (!strncmp(argv[i], "-a:", 3))
+            {
+                audioDeviceIndex = atoi(argv[i] + 3);
             }
             else if (!strcmp(argv[i], "-mk2"))
             {
@@ -1378,7 +1387,7 @@ int main(int argc, char *argv[])
         return 2;
     }
 
-    if (!MCU_OpenAudio())
+    if (!MCU_OpenAudio(audioDeviceIndex))
     {
         fprintf(stderr, "FATAL ERROR: Failed to open the audio stream.\n");
         fflush(stderr);

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -1065,15 +1065,28 @@ int MCU_OpenAudio(int deviceIndex)
     spec.callback = audio_callback;
     spec.samples = audio_page_size / 4;
     
+    int num = SDL_GetNumAudioDevices(0);
+    if (num == 0)
+    {
+        printf("No audio output device found.\n");
+        return 0;
+    }
+    
+    if (deviceIndex < -1 || deviceIndex >= num)
+    {
+        printf("Out of range audio device index is requested. Default audio output device is selected.\n");
+        deviceIndex = -1;
+    }
+    
     const char* audioDevicename = deviceIndex == -1 ? "Default device" : SDL_GetAudioDeviceName(deviceIndex, 0);
-
+    
     sdl_audio = SDL_OpenAudioDevice(deviceIndex == -1 ? NULL : audioDevicename, 0, &spec, &spec_actual, 0);
     if (!sdl_audio)
     {
         return 0;
     }
-    
-    printf("Audio Device: %s\n", audioDevicename);
+
+    printf("Audio device: %s\n", audioDevicename);
 
     printf("Audio Requested: F=%s, C=%d, R=%d, B=%d\n",
            audio_format_to_str(spec.format),

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -1065,9 +1065,9 @@ int MCU_OpenAudio(int deviceIndex)
     spec.callback = audio_callback;
     spec.samples = audio_page_size / 4;
     
-    const char* audioDevicename = SDL_GetAudioDeviceName(deviceIndex, 0);
+    const char* audioDevicename = deviceIndex == -1 ? "Default device" : SDL_GetAudioDeviceName(deviceIndex, 0);
 
-    sdl_audio = SDL_OpenAudioDevice(audioDevicename, 0, &spec, &spec_actual, 0);
+    sdl_audio = SDL_OpenAudioDevice(deviceIndex == -1 ? NULL : audioDevicename, 0, &spec, &spec_actual, 0);
     if (!sdl_audio)
     {
         return 0;
@@ -1155,7 +1155,7 @@ int main(int argc, char *argv[])
     std::string basePath;
 
     int port = 0;
-    int audioDeviceIndex = 0;
+    int audioDeviceIndex = -1;
     bool autodetect = true;
 
     romset = ROM_SET_MK2;


### PR DESCRIPTION
Use -a:<audio_device_index> command line argument to specify audio output device.