### PR TITLE
Add sign extension to H8/500 CMP:G.W #imm8,<EAd> instruction

### DIFF
--- a/src/mcu_opcodes.cpp
+++ b/src/mcu_opcodes.cpp
@@ -834,7 +834,7 @@ void MCU_Opcode_MOVG_Immediate(uint8_t opcode, uint8_t opcode_reg)
     else if (opcode_reg == 4 && (operand_type == GENERAL_INDIRECT || operand_type == GENERAL_ABSOLUTE) && operand_size == OPERAND_WORD) // FIXME
     {
         uint32_t t1 = MCU_Operand_Read();
-        uint32_t t2 = MCU_ReadCodeAdvance();
+        uint32_t t2 = (uint16_t)((int8_t)MCU_ReadCodeAdvance());
         MCU_SUB_Common(t1, t2, 0, OPERAND_WORD);
     }
     else if (opcode_reg == 5 && (operand_type == GENERAL_INDIRECT || operand_type == GENERAL_ABSOLUTE) && operand_size == OPERAND_WORD)


### PR DESCRIPTION
I wasn't able to find documentation on what happenes when the operand size and immediate size of `CMP:G.W` mismatches. (The disassembler DASMH85 that I was using also choked on such opcode.)

However in the ROM code handling DRUM SysEx parameters, there was an instruction that was comparing a word sized memory containing 0xFFFF with a byte sized immediate 0xFF. When I changed the H8/500 emulation to sign extend the immediate byte in such cases, the "DT1 Data Error" (#20, #21) disappeared.