### PR TITLE
Save SRAM on exit

### DIFF
--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -63,6 +63,18 @@ const char* rs_name[ROM_SET_COUNT] = {
     "SC-155mk2"
 };
 
+const char* rs_shortname[ROM_SET_COUNT] = {
+    "sc55mk2",
+    "sc55st",
+    "sc55mk1",
+    "cm300",
+	"jv880",
+	"scb88",
+	"rlp3237",
+	"sc155",
+	"sc155mk2"
+};
+
 static const int ROM_SET_N_FILES = 6;
 
 const char* roms[ROM_SET_COUNT][ROM_SET_N_FILES] =
@@ -1755,6 +1767,23 @@ int main(int argc, char *argv[])
         fflush(stderr);
     }
 
+    std::string sramPath = basePath + "/" + rs_shortname[romset] + "_sram.bin";
+    bool hasSram = (romset == ROM_SET_MK2 || romset == ROM_SET_MK1);
+
+    if (hasSram)
+    {
+        auto h = Files::utf8_fopen(sramPath.c_str(), "rb");
+        if (h)
+        {
+            if (fread(tempbuf, 1, SRAM_SIZE, h) == SRAM_SIZE)
+            {
+                printf("Loaded SRAM from %s\n", sramPath.c_str());
+                memcpy(sram, tempbuf, SRAM_SIZE);
+            }
+            fclose(h);
+        }
+    }
+
     LCD_Init();
     MCU_Init();
     MCU_PatchROM();
@@ -1765,6 +1794,13 @@ int main(int argc, char *argv[])
     if (resetType != ResetType::NONE) MIDI_Reset(resetType);
     
     MCU_Run();
+
+    if (hasSram)
+    {
+        auto h = Files::utf8_fopen(sramPath.c_str(), "wb");
+        fwrite(sram, 1, SRAM_SIZE, h);
+        fclose(h);
+    }
 
     MCU_CloseAudio();
     MIDI_Quit();


### PR DESCRIPTION
This saves the contents of SRAM into a file on exit and loads them on startup to emulate the real module's behavior where SRAM is preserved during power down using a battery.

...granted, I don't know much about how the real SC-55 module works, I just made an educated guess and this code does seem to result in correct behavior. This also avoids the annoying bug carried over from real hardware where the module becomes out of tune if powered up with no battery until you reset it.

Fixes https://github.com/nukeykt/Nuked-SC55/issues/23, fixes https://github.com/nukeykt/Nuked-SC55/issues/45.