### PR TITLE
Output 32-bit float samples to preserve dynamic range and prevent clipping

### DIFF
--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -46,6 +46,11 @@
 #include "utf8main.h"
 #include "utils/files.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
 #if __linux__
 #include <unistd.h>
 #include <limits.h>
@@ -925,6 +930,11 @@ void MCU_WorkThread_Unlock(void)
 
 int SDLCALL work_thread(void* data)
 {
+
+#ifdef _WIN32
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
+#endif
+   
     work_thread_lock = SDL_CreateMutex();
 
     MCU_WorkThread_Lock();
@@ -1313,6 +1323,10 @@ int main(int argc, char *argv[])
 {
     (void)argc;
     std::string basePath;
+
+#ifdef _WIN32
+    SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
+#endif
 
     int port = 0;
     int audioDeviceIndex = -1;

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -1239,9 +1239,7 @@ void MCU_PostSample(int *sample)
     }
     else if (sample_buffer_float)
     {
-        const float divRec = 1 / 32768.0f;
-        sample[0] >>= 14;
-        sample[1] >>= 14;
+        const float divRec = 1 / 536870912.0f;       
         sample_buffer_float[sample_write_ptr + 0] = sample[0] * divRec;
         sample_buffer_float[sample_write_ptr + 1] = sample[1] * divRec;
     }


### PR DESCRIPTION
Added '-af' option to output 32-bit float samples in order to preserve dynamic range and prevent clipping at the same time.