### PR TITLE
Fix windows builds failing to link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,10 @@ endif()
 add_executable(nuked-sc55 ${SC55_SRC} ${UTF8MAIN_SRCS})
 set_nopie(nuked-sc55)
 
+if(MSVC)
+    target_compile_definitions(nuked-sc55 PRIVATE WIN32_CONSOLE)
+endif()
+
 if(TARGET SDL2::SDL2)
     target_link_libraries(nuked-sc55 PRIVATE SDL2::SDL2)
 else()


### PR DESCRIPTION
If WIN32_CONSOLE is not defined, the exe will fail to link:

```
[build] MSVCRT.lib(exe_main.obj) : error LNK2019: unresolved external symbol main referenced in function "int __cdecl __scrt_common_main_seh(void)" (?__scrt_common_main_seh@@YAHXZ) [F:\workspace\Nuked-SC55\build\nuked-sc55.vcxproj]
```

Defining WIN32_CONSOLE in the CFLAGS fixes the issue

fixes #16 