### PR TITLE
Threading and overrun/underrun

### DIFF
--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -414,8 +414,6 @@ void LCD_Update(void)
 
     if (!mcu_cm300 && !mcu_st && !mcu_scb55)
     {
-        MCU_WorkThread_Lock();
-
         if (!lcd_enable && !mcu_jv880)
         {
             memset(lcd_buffer, 0, sizeof(lcd_buffer));
@@ -511,8 +509,6 @@ void LCD_Update(void)
                 }
             }
         }
-
-        MCU_WorkThread_Unlock();
 
         SDL_UpdateTexture(texture, NULL, lcd_buffer, lcd_width_max * 4);
         SDL_RenderCopy(renderer, texture, NULL, NULL);

--- a/src/mcu.h
+++ b/src/mcu.h
@@ -450,6 +450,3 @@ void MCU_EncoderTrigger(int dir);
 
 void MCU_PostSample(int *sample);
 void MCU_PostUART(uint8_t data);
-
-void MCU_WorkThread_Lock(void);
-void MCU_WorkThread_Unlock(void);


### PR DESCRIPTION
This PR isn't meant to be taken as is.  It's to generate a conversation about architecture.  Currently the MCU and LCD main loops are both wholly constrained by the work thread mutex.  So there is no threading benefit as neither can run while the other has the mutex.  I haven't deep dived the LCD loop yet, but in this PR, I've done a more classical approach to updating visuals on a 60 fps time scale.

Also the read/write pointers aren't managed and the current setup only works if you generate exactly as many samples as you need for the callback each time.  That doesn't work on my machine and probably a lot of others.  This PR reports the over/under runs but the output is very crackly as there's not enough samples to fill the time.