### PR TITLE
JV880 bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supported models:
 - SC-55mk1 (v1.21/v2.0 firmwares are confirmed to work)
 - CM-300/SCC-1 (v1.10/v1.20 firmwares are confirmed to work)
 - SC-55st (v1.01)
-- JV-880 (v1.0.0)
+- JV-880 (v1.0.0/v1.0.1)
 - SCB-55/RLP-3194
 - RLP-3237
 - SC-155

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ R15199810 (H8/532 mcu) -> jv880_rom1.bin
 R15209386 (H8/532 extra code) -> jv880_rom2.bin
 R15209312 (WAVE A) -> jv880_waverom1.bin
 R15209313 (WAVE B) -> jv880_waverom2.bin
+PCM Cards -> jv880_waverom_pcmcard.bin (optional)
 Expansion PCBs -> jv880_waverom_expansion.bin (optional)
 
 SCB-55/RLP-3194:

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -426,7 +426,7 @@ void LCD_Update(void)
             {
                 for (size_t i = 0; i < lcd_height; i++) {
                     for (size_t j = 0; j < lcd_width; j++) {
-                        lcd_buffer[i][j] = 0xFF0F6FFF;
+                        lcd_buffer[i][j] = 0xFF03be51;
                     }
                 }
             }

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -39,6 +39,9 @@
 extern int lcd_width;
 extern int lcd_height;
 
+extern uint32_t lcd_col1;
+extern uint32_t lcd_col2;
+
 void LCD_SetBackPath(const std::string &path);
 void LCD_Init(void);
 void LCD_UnInit(void);

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -63,47 +63,56 @@ const char* rs_name[ROM_SET_COUNT] = {
     "SC-155mk2"
 };
 
-const char* roms[ROM_SET_COUNT][5] =
+static const int ROM_SET_N_FILES = 6;
+
+const char* roms[ROM_SET_COUNT][ROM_SET_N_FILES] =
 {
     "rom1.bin",
     "rom2.bin",
     "waverom1.bin",
     "waverom2.bin",
     "rom_sm.bin",
+    "",
 
     "rom1.bin",
     "rom2_st.bin",
     "waverom1.bin",
     "waverom2.bin",
     "rom_sm.bin",
+    "",
 
     "sc55_rom1.bin",
     "sc55_rom2.bin",
     "sc55_waverom1.bin",
     "sc55_waverom2.bin",
     "sc55_waverom3.bin",
+    "",
 
     "cm300_rom1.bin",
     "cm300_rom2.bin",
     "cm300_waverom1.bin",
     "cm300_waverom2.bin",
     "cm300_waverom3.bin",
+    "",
 
     "jv880_rom1.bin",
     "jv880_rom2.bin",
     "jv880_waverom1.bin",
     "jv880_waverom2.bin",
     "jv880_waverom_expansion.bin",
+    "jv880_waverom_pcmcard.bin",
 
     "scb55_rom1.bin",
     "scb55_rom2.bin",
     "scb55_waverom1.bin",
     "scb55_waverom2.bin",
     "",
+    "",
 
     "rlp3237_rom1.bin",
     "rlp3237_rom2.bin",
     "rlp3237_waverom1.bin",
+    "",
     "",
     "",
 
@@ -112,12 +121,14 @@ const char* roms[ROM_SET_COUNT][5] =
     "sc155_waverom1.bin",
     "sc155_waverom2.bin",
     "sc155_waverom3.bin",
+    "",
 
     "rom1.bin",
     "rom2.bin",
     "waverom1.bin",
     "waverom2.bin",
     "rom_sm.bin",
+    "",
 };
 
 int romset = ROM_SET_MK2;
@@ -1564,12 +1575,12 @@ int main(int argc, char *argv[])
             break;
     }
 
-    std::string rpaths[5];
+    std::string rpaths[ROM_SET_N_FILES];
 
     bool r_ok = true;
     std::string errors_list;
 
-    for(size_t i = 0; i < 5; ++i)
+    for(size_t i = 0; i < ROM_SET_N_FILES; ++i)
     {
         if (roms[romset][i][0] == '\0')
         {
@@ -1578,7 +1589,7 @@ int main(int argc, char *argv[])
         }
         rpaths[i] = basePath + "/" + roms[romset][i];
         s_rf[i] = Files::utf8_fopen(rpaths[i].c_str(), "rb");
-        bool optional = mcu_jv880 && i == 4;
+        bool optional = mcu_jv880 && i >= 4;
         r_ok &= optional || (s_rf[i] != nullptr);
         if(!s_rf[i])
         {
@@ -1677,11 +1688,16 @@ int main(int argc, char *argv[])
         }
 
         unscramble(tempbuf, waverom2, 0x200000);
-
+        
         if (s_rf[4] && fread(tempbuf, 1, 0x800000, s_rf[4]))
             unscramble(tempbuf, waverom_exp, 0x800000);
         else
             printf("WaveRom EXP not found, skipping it.\n");
+        
+        if (s_rf[5] && fread(tempbuf, 1, 0x100000, s_rf[5]))
+            unscramble(tempbuf, waverom_card, 0x100000);
+        else
+            printf("WaveRom PCM not found, skipping it.\n");
     }
     else
     {

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -855,6 +855,10 @@ void MCU_Write(uint32_t address, uint8_t value)
                 }
             }
         }
+        else if (mcu_jv880 && address >= 0x6196 && address <= 0x6199)
+        {
+            // nop: the jv880 rom writes into the rom at 002E77-002E7D
+        }
         else
         {
             printf("Unknown write %x %x\n", address, value);

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -1555,6 +1555,8 @@ int main(int argc, char *argv[])
             rom2_mask /= 2; // rom is half the size
             lcd_width = 820;
             lcd_height = 100;
+            lcd_col1 = 0x000000;
+            lcd_col2 = 0x78b500;
             break;
         case ROM_SET_SCB55:
         case ROM_SET_RLP3237:

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -1694,8 +1694,8 @@ int main(int argc, char *argv[])
         else
             printf("WaveRom EXP not found, skipping it.\n");
         
-        if (s_rf[5] && fread(tempbuf, 1, 0x100000, s_rf[5]))
-            unscramble(tempbuf, waverom_card, 0x100000);
+        if (s_rf[5] && fread(tempbuf, 1, 0x200000, s_rf[5]))
+            unscramble(tempbuf, waverom_card, 0x200000);
         else
             printf("WaveRom PCM not found, skipping it.\n");
     }

--- a/src/mcu_opcodes.cpp
+++ b/src/mcu_opcodes.cpp
@@ -983,8 +983,7 @@ void MCU_Opcode_CLR(uint8_t opcode, uint8_t opcode_reg)
         uint32_t data_l = data & 0xff;
         data = (data_l << 8) | data_h;
         mcu.r[operand_reg] = data;
-        MCU_SetStatusCommon(data, OPERAND_BYTE); // FIXME: might be WORD???
-        //MCU_SetStatusCommon(data, OPERAND_WORD);
+        MCU_SetStatusCommon(data, OPERAND_WORD);
     }
     else if (opcode_reg == 5 && operand_type != GENERAL_IMMEDIATE) // NOT
     {

--- a/src/pcm.cpp
+++ b/src/pcm.cpp
@@ -42,6 +42,7 @@ pcm_t pcm;
 uint8_t waverom1[0x200000];
 uint8_t waverom2[0x200000];
 uint8_t waverom3[0x100000];
+uint8_t waverom_card[0x100000];
 uint8_t waverom_exp[0x800000];
 
 uint8_t PCM_ReadROM(uint32_t address)
@@ -64,8 +65,10 @@ uint8_t PCM_ReadROM(uint32_t address)
             else
                 return waverom2[address & 0x1fffff];
         case 2:
-            if (mcu_jv880) return 0;
-            return waverom3[address & 0xfffff];
+            if (mcu_jv880)
+                return waverom_card[address & 0xfffff];
+            else
+                return waverom3[address & 0xfffff];
         case 3:
         case 4:
         case 5:

--- a/src/pcm.cpp
+++ b/src/pcm.cpp
@@ -42,7 +42,7 @@ pcm_t pcm;
 uint8_t waverom1[0x200000];
 uint8_t waverom2[0x200000];
 uint8_t waverom3[0x100000];
-uint8_t waverom_card[0x100000];
+uint8_t waverom_card[0x200000];
 uint8_t waverom_exp[0x800000];
 
 uint8_t PCM_ReadROM(uint32_t address)
@@ -66,7 +66,7 @@ uint8_t PCM_ReadROM(uint32_t address)
                 return waverom2[address & 0x1fffff];
         case 2:
             if (mcu_jv880)
-                return waverom_card[address & 0xfffff];
+                return waverom_card[address & 0x1fffff];
             else
                 return waverom3[address & 0xfffff];
         case 3:

--- a/src/pcm.h
+++ b/src/pcm.h
@@ -67,6 +67,7 @@ extern pcm_t pcm;
 extern uint8_t waverom1[];
 extern uint8_t waverom2[];
 extern uint8_t waverom3[];
+extern uint8_t waverom_card[];
 extern uint8_t waverom_exp[];
 
 void PCM_Write(uint32_t address, uint8_t data);


### PR DESCRIPTION
- Added support for SO-JD and SO-PCM1 cards (thanks @PythonBlue)
- Fixes the behavior of the `SWAP` instruction which was causing a wrong interpretation of midi control change data, which caused modulation to not work properly and cause weird glitches
- Mutes a warning about the CPU writing in ROM area: I've checked the ROM behavior with a disassembler and it's likely a bad copy paste done by Roland
- Added a custom color to better match the original device
   <img width="932" alt="image" src="https://github.com/nukeykt/Nuked-SC55/assets/1353142/f3427184-46ec-47f8-9c82-2448f4ee5a4c">
