### PR TITLE
Fixed basePath for macOS

### DIFF
--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -51,6 +51,10 @@
 #include <limits.h>
 #endif
 
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
 const char* rs_name[ROM_SET_COUNT] = {
     "SC-55mk2",
     "SC-55st",
@@ -1489,22 +1493,27 @@ int main(int argc, char *argv[])
         }
     }
 
-#if __linux__
+#if __linux__ || __APPLE__
     char self_path[PATH_MAX];
     memset(&self_path[0], 0, PATH_MAX);
 
+#if __linux__
     if(readlink("/proc/self/exe", self_path, PATH_MAX) == -1)
+#else
+    uint32_t path_max_size = PATH_MAX;
+    if(_NSGetExecutablePath(self_path, &path_max_size) == -1)
+#endif
         basePath = Files::real_dirname(argv[0]);
     else
-        basePath = Files::dirname(self_path);
+        basePath = Files::real_dirname(self_path);
 #else
     basePath = Files::real_dirname(argv[0]);
 #endif
 
-    printf("Base path is: %s\n", argv[0]);
-
     if(Files::dirExists(basePath + "/../share/nuked-sc55"))
         basePath += "/../share/nuked-sc55";
+
+    printf("Base path is: %s\n", basePath.c_str());
 
     if (autodetect)
     {


### PR DESCRIPTION
For macOS the executable doesn't use the executable binary location to infer the basePath.

Because of this an installed nuked-sc55 will require the back.data and the roms to be in the current directory to work. This PR implements a similar approach as it was done for Linux to define the basePath and fix the problem.

As this change touches the same lines as #66 and will cause conflicts I had also changed: `basePath = Files::dirname(self_path);` into `basePath = Files::real_dirname(self_path);` and changed the console of of the basePath to happen after the check for `../shared/nuked-sc55` and to use `basePath` instead of `argv[0]`. So this PR also achieves the same results as #66.