### PR TITLE
Add MIDI port listing

### DIFF
--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -1375,6 +1375,7 @@ int main(int argc, char *argv[])
     int pageNum = 32;
     bool autodetect = true;
     ResetType resetType = ResetType::NONE;
+    bool listMidi = false;
 
     romset = ROM_SET_MK2;
 
@@ -1453,6 +1454,10 @@ int main(int argc, char *argv[])
             {
                 resetType = ResetType::GM_RESET;
             }
+            else if (!strcmp(argv[i], "-pl"))
+            {
+                listMidi = true;
+            }
             else if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "-help") || !strcmp(argv[i], "--help"))
             {
                 // TODO: Might want to try to find a way to print out the executable's actual name (without any full paths).
@@ -1474,6 +1479,8 @@ int main(int argc, char *argv[])
                 printf("\n");
                 printf("  -gs                            Reset system in GS mode.\n");
                 printf("  -gm                            Reset system in GM mode.\n");
+                printf("\n");
+                printf("  -pl                            List all MIDI ports.\n");
                 return 0;
             }
             else if (!strcmp(argv[i], "-sc155"))
@@ -1749,7 +1756,7 @@ int main(int argc, char *argv[])
         return 2;
     }
 
-    if(!MIDI_Init(port))
+    if(!MIDI_Init(port, listMidi))
     {
         fprintf(stderr, "ERROR: Failed to initialize the MIDI Input.\nWARNING: Continuing without MIDI Input...\n");
         fflush(stderr);

--- a/src/midi.h
+++ b/src/midi.h
@@ -33,6 +33,6 @@
  */
 #pragma once
 
-int MIDI_Init(int port);
+int MIDI_Init(int port, bool listMidi);
 void MIDI_Quit(void);
 

--- a/src/midi_rtmidi.cpp
+++ b/src/midi_rtmidi.cpp
@@ -21,7 +21,7 @@ static void MidiOnError(RtMidiError::Type, const std::string &errorText, void *)
     fflush(stderr);
 }
 
-int MIDI_Init(int port)
+int MIDI_Init(int port, bool listMidi)
 {
     if (s_midi_in)
     {
@@ -35,6 +35,12 @@ int MIDI_Init(int port)
     s_midi_in->setErrorCallback(&MidiOnError, nullptr);
 
     unsigned count = s_midi_in->getPortCount();
+
+    if (listMidi) {
+        for (unsigned i = 0; i < count; i++) {
+            printf("Port[%u]: %s\n", i, s_midi_in->getPortName(i).c_str());
+        }
+    }
 
     if (count == 0)
     {

--- a/src/midi_win32.cpp
+++ b/src/midi_win32.cpp
@@ -111,20 +111,11 @@ int MIDI_Init(int port, bool listMidi)
         return 0;
     }
 
-    if (listMidi) {
+    if (listMidi) {              
         for (int i = 0; i < num; i++) {
-            auto res = midiInOpen(&midi_handle, i, (DWORD_PTR)MIDI_Callback, 0, CALLBACK_FUNCTION);
-            
-            if (res != MMSYSERR_NOERROR) {
-                printf("Can't open midi input\n");
-                return 0;
-            }
-            
-            LPUINT puDeviceId;
-            midiInGetId(&midi_handle, &puDeviceId);
-            printf("Port[%u]: %s\n", i, puDeviceId);
-            
-            Midi_Quit();            
+            MIDIINCAPSA caps;
+            midiInGetDevCapsA(i, &caps, sizeof(MIDIINCAPSA));
+            printf("Port[%d]: %s\n", i, caps.szPname);
         }
     }
 

--- a/src/midi_win32.cpp
+++ b/src/midi_win32.cpp
@@ -101,7 +101,7 @@ void CALLBACK MIDI_Callback(
     }
 }
 
-int MIDI_Init(int port)
+int MIDI_Init(int port, bool listMidi)
 {
     int num = midiInGetNumDevs();
 
@@ -109,6 +109,23 @@ int MIDI_Init(int port)
     {
         printf("No midi input\n");
         return 0;
+    }
+
+    if (listMidi) {
+        for (int i = 0; i < num; i++) {
+            auto res = midiInOpen(&midi_handle, i, (DWORD_PTR)MIDI_Callback, 0, CALLBACK_FUNCTION);
+            
+            if (res != MMSYSERR_NOERROR) {
+                printf("Can't open midi input\n");
+                return 0;
+            }
+            
+            LPUINT puDeviceId;
+            midiInGetId(&midi_handle, &puDeviceId);
+            printf("Port[%u]: %s\n", i, puDeviceId);
+            
+            Midi_Quit();            
+        }
     }
 
     if (port < 0 || port >= num)


### PR DESCRIPTION
Adds an option `-pl` to list MIDI ports. 

When testing this emulator, I was struggling to tell what my MIDI ports were as I have multiple MIDI devices plugged in, some with multiple ports. This helped me determine the one I wished to use.