### PR TITLE
mcu_opcodes/SHAR: don't strip MSB before shifting

### DIFF
--- a/src/mcu_opcodes.cpp
+++ b/src/mcu_opcodes.cpp
@@ -1307,12 +1307,12 @@ void MCU_Opcode_SHLR(uint8_t opcode, uint8_t opcode_reg)
         if (operand_size)
         {
             msb = data & 0x8000;
-            data &= 0x7fff;
+            data &= 0xffff;
         }
         else
         {
             msb = data & 0x80;
-            data &= 0x7f;
+            data &= 0xff;
         }
         data >>= 1;
         data |= msb;


### PR DESCRIPTION
Hi, I'm currently in the process of rewriting the H8/532 VM, and I came across a potential bug in the current implementation of SHAR.

The current implementation strips the operand MSB before shifting the operand right, so the bit below the MSB will always be 0 afterwards. This means that SHAR is not equivalent to division by 2. The result is correct for positive signed integers, but incorrect for negative ones. This seems to only affect the JV880.

Some examples of the current behavior:
```
SHAR.B -128 => -128
SHAR.B -120 => -124
SHAR.B -1   => -65
```

With this PR:
```
SHAR.B -128 => -64
SHAR.B -120 => -60
SHAR.B -1   => -1
```

Let me know if I've misunderstood something.