### PR TITLE
mcu_timer: initialize fields from manual

### DIFF
--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -1761,6 +1761,7 @@ int main(int argc, char *argv[])
     MCU_Reset();
     SM_Reset();
     PCM_Reset();
+    TIMER_Reset();
 
     if (resetType != ResetType::NONE) MIDI_Reset(resetType);
     

--- a/src/mcu_timer.cpp
+++ b/src/mcu_timer.cpp
@@ -60,7 +60,15 @@ void TIMER_Reset(void)
     timer_cycles = 0;
     timer_tempreg = 0;
     memset(frt, 0, sizeof(frt));
+    for (int i = 0; i < 3; ++i)
+    {
+        frt[i].ocra = 0xffff;
+        frt[i].ocrb = 0xffff;
+    }
     memset(&timer, 0, sizeof(timer));
+    timer.tcora = 0xff;
+    timer.tcorb = 0xff;
+    timer.tcsr = 0x10;
 }
 
 void TIMER_Write(uint32_t address, uint8_t data)

--- a/src/mcu_timer.h
+++ b/src/mcu_timer.h
@@ -53,6 +53,8 @@ struct mcu_timer_t {
     uint8_t status_rd;
 };
 
+void TIMER_Reset(void);
+
 void TIMER_Write(uint32_t address, uint8_t data);
 uint8_t TIMER_Read(uint32_t address);
 void TIMER_Clock(uint64_t cycles);


### PR DESCRIPTION
Hi,

According to the H8/532 manual, the following timer registers have initial values other than zero:

FRT register | initial value
-|-
OCRA | `0xffff`
OCRB | `0xffff`

8-bit timer register | initial value
-|-
TCSR | `0x10`
TCORA | `0xff`
TCORB | `0xff`

Currently these are initialized to zero. This doesn't matter for most romsets I've tested, but it does affect cm300-v1.10 output and possibly others.